### PR TITLE
fix: reject reserved slugs when creating a link

### DIFF
--- a/shared/schemas/link.ts
+++ b/shared/schemas/link.ts
@@ -2,7 +2,10 @@ import { customAlphabet } from 'nanoid'
 import { z } from 'zod'
 import { LINK_PASSWORD_MASK_PREFIX } from '../utils/link-password'
 
-const { slugRegex } = useAppConfig()
+const { slugRegex, reserveSlug } = useAppConfig()
+
+// The shared layer does not receive `app/app.config.ts` types, so annotate what it reads.
+const reservedSlugs = new Set((reserveSlug as string[]).map(slug => slug.toLowerCase()))
 
 const slugDefaultLength = +useRuntimeConfig().public.slugDefaultLength
 
@@ -36,6 +39,15 @@ export const EditLinkPasswordSchema = z.string().trim().max(128).refine(
 const IdSchema = z.string().trim().min(1).max(26)
 export const UrlSchema = z.string().trim().url().max(2048)
 export const SlugSchema = z.string().trim().max(2048).regex(new RegExp(slugRegex))
+// `server/middleware/1.redirect.ts` skips reserved slugs before it looks a link up, so a
+// link written to one never redirects. Reject them where new links come in, and compare
+// case-insensitively because write paths lowercase the slug unless `caseSensitive` is set.
+// Never apply this to stored or legacy KV records: links written before this check must
+// stay readable, exportable, and deletable.
+const NewSlugSchema = SlugSchema.refine(
+  slug => !reservedSlugs.has(slug.toLowerCase()),
+  'slug is reserved',
+)
 const TimestampSchema = z.number().int().safe()
 const ExpirationSchema = TimestampSchema.refine(expiration => expiration > Math.floor(Date.now() / 1000), {
   message: 'expiration must be greater than current time',
@@ -62,7 +74,7 @@ const LinkFieldsSchema = z.object({
 
 export const CreateLinkSchema = LinkFieldsSchema.extend({
   id: IdSchema.default(nanoid(10)),
-  slug: SlugSchema.default(nanoid()),
+  slug: NewSlugSchema.default(nanoid()),
   createdAt: TimestampSchema.default(() => Math.floor(Date.now() / 1000)),
   updatedAt: TimestampSchema.default(() => Math.floor(Date.now() / 1000)),
 })
@@ -72,6 +84,7 @@ export const EditLinkSchema = LinkFieldsSchema.extend({
 })
 
 export const ImportLinkSchema = LinkFieldsSchema.extend({
+  slug: NewSlugSchema,
   id: z.preprocess(value => typeof value === 'string' && !value.trim() ? undefined : value, IdSchema.optional()),
   createdAt: TimestampSchema.optional(),
   updatedAt: TimestampSchema.optional(),

--- a/tests/api/link-d1.spec.ts
+++ b/tests/api/link-d1.spec.ts
@@ -292,6 +292,22 @@ describe('d1 link integration', () => {
     expect(await query.json()).toMatchObject({ tags: ['legacy-tag'] })
   })
 
+  it('keeps a legacy KV link on a reserved slug readable and editable', async () => {
+    await clearLinkMigrationState()
+    const link = makeLink('dashboard')
+    await putKvLink(link)
+
+    await runMigration(false)
+
+    expect(await getD1Link(link.slug)).toMatchObject({ slug: link.slug, url: link.url })
+    const query = await fetchWithAuth(`/api/link/query?slug=${link.slug}`)
+    expect(query.status).toBe(200)
+
+    const edit = await putJson('/api/link/edit', { slug: link.slug, url: 'https://example.com/reserved-edit' })
+    expect(edit.status).toBe(201)
+    expect(await getD1Link(link.slug)).toMatchObject({ url: 'https://example.com/reserved-edit' })
+  })
+
   it('does not let a conflicting edit overwrite tags from the successful edit', async () => {
     const link = makeLink()
     expect((await postJson('/api/link/create', link)).status).toBe(201)

--- a/tests/api/link-migration.spec.ts
+++ b/tests/api/link-migration.spec.ts
@@ -213,6 +213,15 @@ describe('/api/link/import', { concurrent: false }, () => {
     expect(response.status).toBe(400)
   })
 
+  it('returns 400 for a reserved slug in links', async () => {
+    const response = await postJson('/api/link/import', {
+      version: '1.0',
+      links: [{ url: 'https://example.com', slug: 'dashboard' }],
+    })
+    expect(response.status).toBe(400)
+    expect(await getStoredLink('dashboard')).toBeNull()
+  })
+
   it('returns 400 when an imported link is missing its slug', async () => {
     const response = await postJson('/api/link/import', {
       version: '1.0',

--- a/tests/api/link.spec.ts
+++ b/tests/api/link.spec.ts
@@ -148,6 +148,27 @@ describe('/api/link/create', { concurrent: false }, () => {
     expect(response.status).toBe(400)
   })
 
+  it('returns 400 when slug is reserved', async () => {
+    const response = await postJson('/api/link/create', { url: 'https://example.com', slug: 'dashboard' })
+    expect(response.status).toBe(400)
+    expect(await getStoredLink('dashboard')).toBeNull()
+  })
+
+  it('returns 400 when slug only differs from a reserved slug by case', async () => {
+    const response = await postJson('/api/link/create', { url: 'https://example.com', slug: 'Dashboard' })
+    expect(response.status).toBe(400)
+    expect(await getStoredLink('dashboard')).toBeNull()
+  })
+
+  it('creates a link whose slug only contains a reserved slug', async () => {
+    const slug = trackSlug(`dashboard-${crypto.randomUUID()}`)
+    const response = await postJson('/api/link/create', { url: 'https://example.com', slug })
+    expect(response.status).toBe(201)
+
+    const data = await response.json() as { link: { slug: string } }
+    expect(data.link.slug).toBe(slug)
+  })
+
   it('accepts lowercase geo key and returns uppercase key', async () => {
     const slug = trackSlug(`geo-lower-${crypto.randomUUID()}`)
     const response = await postJson('/api/link/create', {
@@ -198,6 +219,12 @@ describe('/api/link/upsert', { concurrent: false }, () => {
 
     const response = await postJson('/api/link/upsert', { ...payload, url: 'https://updated.example.com' })
     expect(response.status).toBe(200)
+  })
+
+  it('returns 400 when slug is reserved', async () => {
+    const response = await postJson('/api/link/upsert', { url: 'https://example.com', slug: 'dashboard' })
+    expect(response.status).toBe(400)
+    expect(await getStoredLink('dashboard')).toBeNull()
   })
 
   it('masks password in response and stores hashed password', async () => {


### PR DESCRIPTION
## The bug

`app/app.config.ts` declares `reserveSlug: ['dashboard']`, but that array is read in exactly one place: `server/middleware/1.redirect.ts`.

```ts
if (slug && !reserveSlug.includes(slug) && slugRegex.test(slug) && cloudflare) {
```

The middleware skips reserved slugs *before* it ever looks the link up. Nothing checks the list at write time, so `SlugSchema` happily accepts `dashboard`.

**Reproduction:** create a link on slug `dashboard`, from the dashboard UI or `POST /api/link/create`. It saves with a 201, appears in the link list, and `/dashboard` never redirects to it. No error, no warning — the link just quietly does nothing forever.

## The fix

Reject reserved slugs in the schemas that validate new links, so the API answers 400 instead of storing a dead link.

- `CreateLinkSchema` (used by `/api/link/create` and `/api/link/upsert`)
- `ImportLinkSchema` (used by `/api/link/import`)

## Case sensitivity

The middleware's `reserveSlug.includes(slug)` compares the raw path segment case-sensitively, so a request to `/Dashboard` is not shadowed on its own. The write paths settle the question: `create`, `upsert`, `edit`, and `import` all put the slug through `normalizeSlug()`, which lowercases it unless `caseSensitive` is enabled — and `caseSensitive` defaults to `false`. Under the default configuration a submitted `Dashboard` is stored as `dashboard`, and the canonical short link returned to the user is dead in exactly the same way.

So the check compares case-insensitively, which means the default configuration cannot reach the bug through a capital letter. It is stricter than the middleware in one situation only — a `caseSensitive: true` deployment, where `Dashboard` would have resolved — which costs a new link one alternative slug and keeps a single rule. Happy to make it an exact match instead if you would rather keep validation identical to the middleware guard.

A slug that merely *contains* a reserved word (`dashboard-metrics`) is still accepted; there is a test for that.

## Existing data is deliberately left alone

`StoredLinkSchema` and `parseLegacyKvLink()` are **not** touched. They still accept reserved slugs, so any instance that already has a link on `dashboard` keeps reading, exporting, migrating, and deleting it normally. Adding the check there would turn a silent dead link into a hard parse error on stored data, which is far worse than the bug being fixed.

`EditLinkSchema` is left alone for the same reason: `/api/link/edit` resolves an existing record by slug and 404s when there is none, so it cannot introduce a reserved slug, while rejecting there would lock links created before this fix out of being edited.

## Tests

Six new tests:

- `create` rejects `dashboard` and rejects `Dashboard`, and stores nothing in either case
- `create` still accepts `dashboard-<uuid>`
- `upsert` rejects `dashboard`
- `import` rejects a reserved slug in its payload
- a legacy KV link stored on `dashboard` still migrates into D1, still answers `/api/link/query`, and is still editable — the regression guard for the stored-data contract

Full suite passes with no failures (the pre-existing `Cannot find package 'vue'` collection errors under `tests/unit/` are unchanged from master). `eslint` and `nuxt typecheck` report nothing new for the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)